### PR TITLE
Removes files in spec and test folders from requires_spec lint

### DIFF
--- a/app/models/linters/specs_required.rb
+++ b/app/models/linters/specs_required.rb
@@ -19,6 +19,8 @@ module Linters
       [
         /\Adb/,
         /\Aconfig/,
+        /\Aspec/,
+        /\Atest/,
       ]
     end
 
@@ -76,7 +78,7 @@ module Linters
         linter: Linters::SpecsRequired,
         message: <<-message.squish
           Expected changes or additions to a test file called
-          [#{expected_spec_filename(file)}](#{expected_spec_url(pr, file)})
+          #{expected_spec_filename(file)}
         message
       )
     end
@@ -90,18 +92,6 @@ module Linters
         file_extname = 'rb'
       end
       "#{filename_base}_spec.#{file_extname}"
-    end
-
-    def self.expected_spec_path(file)
-      path_pattern = config_for_extname(file.extname)[:app_path_pattern]
-
-      path_match = File.dirname(path_pattern.match(file.path)[:path]) + '/'
-      path_match = path_match == './' ? '' : path_match
-      "spec/#{path_match}#{expected_spec_filename(file)}"
-    end
-
-    def self.expected_spec_url(pr, file)
-      pr.expected_url_from_path(expected_spec_path(file))
     end
   end
 end

--- a/spec/models/linters/specs_required_spec.rb
+++ b/spec/models/linters/specs_required_spec.rb
@@ -56,24 +56,4 @@ describe Linters::SpecsRequired do
     expect(linter.requires_spec?(pr_with_exemption.files.first)).to be false
   end
 
-  it 'can get the url where a spec should live' do
-    path = 'test.rb'
-    body = 'class Test; end'
-
-    file = StubFile.new(
-      path: path,
-      blob: body,
-      patch: Patch.from_file_body(body),
-    )
-
-    pr = LocalPrAlike.from_json(
-      [
-        file.as_json,
-      ],
-    )
-
-    expect(
-      Linters::SpecsRequired.expected_spec_url(pr, file),
-    ).to eq 'spec/test_spec.rb'
-  end
 end


### PR DESCRIPTION
An unrelated test is failing, and I should probably add more tests, but wanted to start the PR to start the diff comparison.